### PR TITLE
Add missing migration import for setup processing

### DIFF
--- a/packages/contracts/src/Migrations.sol
+++ b/packages/contracts/src/Migrations.sol
@@ -5,5 +5,6 @@ pragma solidity 0.8.17;
 // Import all contracts from other repositories to make the openzeppelin-upgrades package work to deploy things.
 // See related issue here https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/86
 
+import {DAOFactory} from "@aragon/osx/framework/dao/DAOFactory.sol";
 import {PluginSetupProcessor} from "@aragon/osx/framework/plugin/setup/PluginSetupProcessor.sol";
 import {PluginRepoFactory} from "@aragon/osx/framework/plugin/repo/PluginRepoFactory.sol";


### PR DESCRIPTION
On a clean install, setup-processing.ts will fail due to DaoFactory not being imported on Migrations.sol