### PR TITLE
chore: bump OZ and remove ENS dependency

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -42,9 +42,8 @@
   "dependencies": {
     "@aragon/osx": "^1.3.0-rc0.4",
     "@aragon/osx-ethers": "^1.3.0-rc0.4",
-    "@ensdomains/ens-contracts": "0.0.20",
-    "@openzeppelin/contracts": "^4.8.2",
-    "@openzeppelin/contracts-upgradeable": "^4.8.2",
+    "@openzeppelin/contracts": "^4.9.3",
+    "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "@openzeppelin/hardhat-upgrades": "^1.27.0"
   },
   "files": [


### PR DESCRIPTION
Use the latest OZ version, the same we also use in the aragon/osx repo.
Additionally, remove the ENS dependency that is rarely needed.