### PR TITLE
feat: improvements surfaced from the admin plugin

### DIFF
--- a/.github/workflows/contracts-tests.yml
+++ b/.github/workflows/contracts-tests.yml
@@ -36,4 +36,5 @@ jobs:
       - name: 'Test the contracts and generate the coverage report'
         run: 'yarn coverage'
         env:
+          NETWORK_NAME: ${{ vars.NETWORK_NAME }}
           INFURA_API_KEY: ${{ secrets.INFURA_API_KEY }}

--- a/packages/contracts/deploy/00_info/01_info.ts
+++ b/packages/contracts/deploy/00_info/01_info.ts
@@ -4,6 +4,7 @@ import {
   isLocal,
 } from '../../utils/helpers';
 import {getNetworkByNameOrAlias} from '@aragon/osx-commons-configs';
+import {UnsupportedNetworkError} from '@aragon/osx-commons-sdk';
 import {DeployFunction} from 'hardhat-deploy/types';
 import {HardhatRuntimeEnvironment} from 'hardhat/types';
 import path from 'path';
@@ -26,7 +27,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     );
 
     // Fork the network provided in the `.env` file
-    const networkConfig = getNetworkByNameOrAlias(productionNetworkName)!;
+    const networkConfig = getNetworkByNameOrAlias(productionNetworkName);
+    if (networkConfig === null) {
+      throw new UnsupportedNetworkError(productionNetworkName);
+    }
     await hre.network.provider.request({
       method: 'hardhat_reset',
       params: [

--- a/packages/contracts/deploy/10_create_repo/11_create_repo.ts
+++ b/packages/contracts/deploy/10_create_repo/11_create_repo.ts
@@ -70,7 +70,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   );
 
   console.log(
-    `'${pluginEnsDomain(hre)}' PluginRepo deployed at: ${pluginRepo.address}.`
+    `PluginRepo '${pluginEnsDomain(hre)}' deployed at '${pluginRepo.address}'.`
   );
 
   hre.aragonToVerifyContracts.push({

--- a/packages/contracts/deploy/20_new_version/21_setup.ts
+++ b/packages/contracts/deploy/20_new_version/21_setup.ts
@@ -14,11 +14,15 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deploy} = deployments;
   const {deployer} = await getNamedAccounts();
 
-  await deploy(PLUGIN_SETUP_CONTRACT_NAME, {
+  const res = await deploy(PLUGIN_SETUP_CONTRACT_NAME, {
     from: deployer,
     args: [],
     log: true,
   });
+
+  console.log(
+    `Deployed '${PLUGIN_SETUP_CONTRACT_NAME}' contract at '${res.address}'`
+  );
 };
 
 export default func;

--- a/packages/contracts/deploy/30_upgrade_repo/31_upgrade_repo.ts
+++ b/packages/contracts/deploy/30_upgrade_repo/31_upgrade_repo.ts
@@ -53,11 +53,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // Re-initialization will happen through a call to `function initializeFrom(uint8[3] calldata _previousProtocolVersion, bytes calldata _initData)`
   // that Aragon might add to the `PluginRepo` contract once it's required.
   /*
-  // Define the `initData` arguments that 
+  // Define the `_initData` arguments 
   const initData: BytesLike[] = [];
   // Encode the call to `function initializeFrom(uint8[3] calldata _previousProtocolVersion, bytes calldata _initData)` with `initData`
   const initializeFromCalldata =
-    newPluginRepoImplementation.interface.encodeFunctionData('initializeFrom', [
+    latestPluginRepoImplementation.interface.encodeFunctionData('initializeFrom', [
       current,
       initData,
     ]);

--- a/packages/contracts/test/20_integration-testing/21_deployment.ts
+++ b/packages/contracts/test/20_integration-testing/21_deployment.ts
@@ -1,4 +1,4 @@
-import {METADATA} from '../../plugin-settings';
+import {METADATA, VERSION} from '../../plugin-settings';
 import {getProductionNetworkName, findPluginRepo} from '../../utils/helpers';
 import {
   getLatestNetworkDeployment,
@@ -66,13 +66,13 @@ describe(`Deployment on network '${productionNetworkName}'`, function () {
       const {pluginRepo} = await loadFixture(fixture);
 
       await pluginRepo['getVersion((uint8,uint16))']({
-        release: 1,
-        build: 1,
+        release: VERSION.release,
+        build: VERSION.build,
       });
 
       const results = await pluginRepo['getVersion((uint8,uint16))']({
-        release: 1,
-        build: 1,
+        release: VERSION.release,
+        build: VERSION.build,
       });
 
       const buildMetadataURI = `ipfs://${await uploadToIPFS(

--- a/packages/contracts/test/20_integration-testing/22_setup-processing.ts
+++ b/packages/contracts/test/20_integration-testing/22_setup-processing.ts
@@ -28,55 +28,55 @@ import env, {deployments, ethers} from 'hardhat';
 const productionNetworkName = getProductionNetworkName(env);
 
 describe(`PluginSetup processing on network '${productionNetworkName}'`, function () {
-  context('Build 1', async () => {
-    it('installs & uninstalls', async () => {
-      const {deployer, psp, daoMock, pluginSetup, pluginSetupRef} =
-        await loadFixture(fixture);
+  it('installs & uninstalls the current build', async () => {
+    const {deployer, psp, daoMock, pluginSetup, pluginSetupRef} =
+      await loadFixture(fixture);
 
-      // Allow all authorized calls to happen
-      await daoMock.setHasPermissionReturnValueMock(true);
+    // Allow all authorized calls to happen
+    await daoMock.setHasPermissionReturnValueMock(true);
 
-      // Install build 1.
-      const results = await installPLugin(
-        psp,
-        daoMock,
-        pluginSetupRef,
-        ethers.utils.defaultAbiCoder.encode(
-          getNamedTypesFromMetadata(
-            METADATA.build.pluginSetup.prepareInstallation.inputs
-          ),
-          [123]
-        )
-      );
+    // Install the current build.
+    const results = await installPLugin(
+      deployer,
+      psp,
+      daoMock,
+      pluginSetupRef,
+      ethers.utils.defaultAbiCoder.encode(
+        getNamedTypesFromMetadata(
+          METADATA.build.pluginSetup.prepareInstallation.inputs
+        ),
+        [123]
+      )
+    );
 
-      const plugin = MyPlugin__factory.connect(
-        results.preparedEvent.args.plugin,
-        deployer
-      );
+    const plugin = MyPlugin__factory.connect(
+      results.preparedEvent.args.plugin,
+      deployer
+    );
 
-      // Check implementation.
-      expect(await plugin.implementation()).to.be.eq(
-        await pluginSetup.implementation()
-      );
+    // Check implementation.
+    expect(await plugin.implementation()).to.be.eq(
+      await pluginSetup.implementation()
+    );
 
-      // Check state.
-      expect(await plugin.number()).to.eq(123);
+    // Check state.
+    expect(await plugin.number()).to.eq(123);
 
-      // Uninstall build 1.
-      await uninstallPLugin(
-        psp,
-        daoMock,
-        plugin,
-        pluginSetupRef,
-        ethers.utils.defaultAbiCoder.encode(
-          getNamedTypesFromMetadata(
-            METADATA.build.pluginSetup.prepareUninstallation.inputs
-          ),
-          []
+    // Uninstall the current build.
+    await uninstallPLugin(
+      deployer,
+      psp,
+      daoMock,
+      plugin,
+      pluginSetupRef,
+      ethers.utils.defaultAbiCoder.encode(
+        getNamedTypesFromMetadata(
+          METADATA.build.pluginSetup.prepareUninstallation.inputs
         ),
         []
-      );
-    });
+      ),
+      []
+    );
   });
 });
 

--- a/packages/contracts/test/20_integration-testing/test-helpers.ts
+++ b/packages/contracts/test/20_integration-testing/test-helpers.ts
@@ -1,15 +1,22 @@
 import {DAOMock, IPlugin} from '../../typechain';
 import {hashHelpers} from '../../utils/helpers';
-import {findEvent} from '@aragon/osx-commons-sdk';
+import {
+  DAO_PERMISSIONS,
+  PLUGIN_SETUP_PROCESSOR_PERMISSIONS,
+  findEvent,
+} from '@aragon/osx-commons-sdk';
 import {
   PluginSetupProcessorEvents,
   PluginSetupProcessorStructs,
   PluginSetupProcessor,
+  DAOStructs,
 } from '@aragon/osx-ethers';
+import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers';
 import {expect} from 'chai';
 import {ContractTransaction} from 'ethers';
 
 export async function installPLugin(
+  signer: SignerWithAddress,
   psp: PluginSetupProcessor,
   dao: DAOMock,
   pluginSetupRef: PluginSetupProcessorStructs.PluginSetupRefStruct,
@@ -20,7 +27,7 @@ export async function installPLugin(
   preparedEvent: PluginSetupProcessorEvents.InstallationPreparedEvent;
   appliedEvent: PluginSetupProcessorEvents.InstallationAppliedEvent;
 }> {
-  const prepareTx = await psp.prepareInstallation(dao.address, {
+  const prepareTx = await psp.connect(signer).prepareInstallation(dao.address, {
     pluginSetupRef: pluginSetupRef,
     data: data,
   });
@@ -32,11 +39,20 @@ export async function installPLugin(
     );
 
   const plugin = preparedEvent.args.plugin;
+  const preparedPermissions = preparedEvent.args.preparedSetupData.permissions;
 
-  const applyTx = await psp.applyInstallation(dao.address, {
+  await checkPermissions(
+    preparedPermissions,
+    dao,
+    psp,
+    signer,
+    PLUGIN_SETUP_PROCESSOR_PERMISSIONS.APPLY_INSTALLATION_PERMISSION_ID
+  );
+
+  const applyTx = await psp.connect(signer).applyInstallation(dao.address, {
     pluginSetupRef: pluginSetupRef,
     plugin: plugin,
-    permissions: preparedEvent.args.preparedSetupData.permissions,
+    permissions: preparedPermissions,
     helpersHash: hashHelpers(preparedEvent.args.preparedSetupData.helpers),
   });
 
@@ -50,6 +66,7 @@ export async function installPLugin(
 }
 
 export async function uninstallPLugin(
+  signer: SignerWithAddress,
   psp: PluginSetupProcessor,
   dao: DAOMock,
   plugin: IPlugin,
@@ -62,14 +79,16 @@ export async function uninstallPLugin(
   preparedEvent: PluginSetupProcessorEvents.UninstallationPreparedEvent;
   appliedEvent: PluginSetupProcessorEvents.UninstallationAppliedEvent;
 }> {
-  const prepareTx = await psp.prepareUninstallation(dao.address, {
-    pluginSetupRef: pluginSetupRef,
-    setupPayload: {
-      plugin: plugin.address,
-      currentHelpers: currentHelpers,
-      data: data,
-    },
-  });
+  const prepareTx = await psp
+    .connect(signer)
+    .prepareUninstallation(dao.address, {
+      pluginSetupRef: pluginSetupRef,
+      setupPayload: {
+        plugin: plugin.address,
+        currentHelpers: currentHelpers,
+        data: data,
+      },
+    });
 
   const preparedEvent =
     await findEvent<PluginSetupProcessorEvents.UninstallationPreparedEvent>(
@@ -79,7 +98,15 @@ export async function uninstallPLugin(
 
   const preparedPermissions = preparedEvent.args.permissions;
 
-  const applyTx = await psp.applyUninstallation(dao.address, {
+  await checkPermissions(
+    preparedPermissions,
+    dao,
+    psp,
+    signer,
+    PLUGIN_SETUP_PROCESSOR_PERMISSIONS.APPLY_UNINSTALLATION_PERMISSION_ID
+  );
+
+  const applyTx = await psp.connect(signer).applyUninstallation(dao.address, {
     plugin: plugin.address,
     pluginSetupRef: pluginSetupRef,
     permissions: preparedPermissions,
@@ -93,8 +120,8 @@ export async function uninstallPLugin(
 
   return {prepareTx, applyTx, preparedEvent, appliedEvent};
 }
-
 export async function updatePlugin(
+  signer: SignerWithAddress,
   psp: PluginSetupProcessor,
   dao: DAOMock,
   plugin: IPlugin,
@@ -112,7 +139,7 @@ export async function updatePlugin(
     pluginSetupRefUpdate.pluginSetupRepo
   );
 
-  const prepareTx = await psp.prepareUpdate(dao.address, {
+  const prepareTx = await psp.connect(signer).prepareUpdate(dao.address, {
     currentVersionTag: pluginSetupRefCurrent.versionTag,
     newVersionTag: pluginSetupRefUpdate.versionTag,
     pluginSetupRepo: pluginSetupRefUpdate.pluginSetupRepo,
@@ -128,11 +155,21 @@ export async function updatePlugin(
       psp.interface.getEvent('UpdatePrepared').name
     );
 
-  const applyTx = await psp.applyUpdate(dao.address, {
+  const preparedPermissions = preparedEvent.args.preparedSetupData.permissions;
+
+  await checkPermissions(
+    preparedPermissions,
+    dao,
+    psp,
+    signer,
+    PLUGIN_SETUP_PROCESSOR_PERMISSIONS.APPLY_UPDATE_PERMISSION_ID
+  );
+
+  const applyTx = await psp.connect(signer).applyUpdate(dao.address, {
     plugin: plugin.address,
     pluginSetupRef: pluginSetupRefUpdate,
     initData: preparedEvent.args.initData,
-    permissions: preparedEvent.args.preparedSetupData.permissions,
+    permissions: preparedPermissions,
     helpersHash: hashHelpers(preparedEvent.args.preparedSetupData.helpers),
   });
   const appliedEvent =
@@ -142,4 +179,36 @@ export async function updatePlugin(
     );
 
   return {prepareTx, applyTx, preparedEvent, appliedEvent};
+}
+
+async function checkPermissions(
+  preparedPermissions: DAOStructs.MultiTargetPermissionStruct[],
+  dao: DAOMock,
+  psp: PluginSetupProcessor,
+  signer: SignerWithAddress,
+  applyPermissionId: string
+) {
+  if (preparedPermissions.length !== 0) {
+    if (
+      !(await dao.hasPermission(
+        dao.address,
+        psp.address,
+        DAO_PERMISSIONS.ROOT_PERMISSION_ID,
+        []
+      ))
+    ) {
+      throw `The 'PluginSetupProcessor' does not have 'ROOT_PERMISSION_ID' on the DAO and thus cannot process the list of permissions requested by the plugin setup.`;
+    }
+  }
+  if (
+    signer.address !== dao.address &&
+    !(await dao.hasPermission(
+      psp.address,
+      signer.address,
+      applyPermissionId,
+      []
+    ))
+  ) {
+    throw `The used signer does not have the permission with ID '${applyPermissionId}' granted and thus cannot apply the setup`;
+  }
 }

--- a/packages/contracts/utils/helpers.ts
+++ b/packages/contracts/utils/helpers.ts
@@ -68,10 +68,17 @@ export async function findPluginRepo(
 ): Promise<{pluginRepo: PluginRepo | null; ensDomain: string}> {
   const [deployer] = await hre.ethers.getSigners();
   const productionNetworkName: string = getProductionNetworkName(hre);
+  const network = getNetworkNameByAlias(productionNetworkName);
+  if (network === null) {
+    throw new UnsupportedNetworkError(productionNetworkName);
+  }
+  const networkDeployments = getLatestNetworkDeployment(network);
+  if (networkDeployments === null) {
+    throw `Deployments are not available on network ${network}.`;
+  }
 
   const registrar = ENSSubdomainRegistrar__factory.connect(
-    getLatestNetworkDeployment(getNetworkNameByAlias(productionNetworkName)!)!
-      .PluginENSSubdomainRegistrarProxy.address,
+    networkDeployments.PluginENSSubdomainRegistrarProxy.address,
     deployer
   );
 

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -16,15 +16,14 @@
     "clean": "rimraf deploy-output.txt subgraph.yaml ./build ./imported ./generated ./tests/.bin tests/.latest.json && yarn postinstall"
   },
   "devDependencies": {
-    "@aragon/osx-ethers": "1.3.0",
+    "@aragon/osx-ethers": "1.4.0-alpha.0",
+    "@aragon/osx-commons-configs": "0.2.0",
     "@graphprotocol/graph-cli": "^0.51.0",
     "@graphprotocol/graph-ts": "^0.31.0",
     "cross-env": "^7.0.3",
     "dotenv": "^16.3.1",
     "matchstick-as": "^0.5.2",
     "mustache": "^4.2.0",
-    "@aragon/osx-ethers": "1.4.0-alpha.0",
-    "@aragon/osx-commons-configs": "0.2.0",
     "ts-morph": "^17.0.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"


### PR DESCRIPTION
This PR

- improves prints
- uses the input data from the `build-metadata.json` file consequently
- uses the `VERSION` information from the `plugin-settings.ts` file consequently
- adds the signer as and input argument as well as a permission check to the `installPlugin`, `uninstallPlugin` and `updatePlugin` helper functions
- throw explicit errors instead of using the Non-Null Assertion Operator (`!`)

Task ID: [OS-1079](https://aragonassociation.atlassian.net/browse/OS-1079), [OS-1084](https://aragonassociation.atlassian.net/browse/OS-1084)

[OS-1079]: https://aragonassociation.atlassian.net/browse/OS-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OS-1084]: https://aragonassociation.atlassian.net/browse/OS-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ