### PR TITLE
proposal: simplify repo configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,6 @@ NETWORK_NAME="sepolia" #  ["mainnet", "sepolia", "polygon", "polygonMumbai", "ba
 ## One or multiple hex encoded private keys separated by commas `,` replacing the hardhat default accounts.
 PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" # Default hardhat account 0 private key. DON'T USE FOR DEPLOYMENTS
 
-## Infura credentials
-INFURA_API_KEY="zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
-
 ## Gas Reporting
 REPORT_GAS='true'
 COINMARKETCAP_API_KEY="zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"

--- a/packages/contracts/deploy/00_info/01_info.ts
+++ b/packages/contracts/deploy/00_info/01_info.ts
@@ -2,6 +2,7 @@ import {
   AragonOSxAsciiArt,
   getProductionNetworkName,
   isLocal,
+  getNetworkForkConfig,
 } from '../../utils/helpers';
 import {getNetworkByNameOrAlias} from '@aragon/osx-commons-configs';
 import {UnsupportedNetworkError} from '@aragon/osx-commons-sdk';
@@ -31,12 +32,16 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     if (networkConfig === null) {
       throw new UnsupportedNetworkError(productionNetworkName);
     }
+    const blockNumber = getNetworkForkConfig(
+      productionNetworkName
+    )?.blockNumber;
     await hre.network.provider.request({
       method: 'hardhat_reset',
       params: [
         {
           forking: {
             jsonRpcUrl: networkConfig.url,
+            blockNumber: blockNumber,
           },
         },
       ],

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -24,10 +24,6 @@ import 'solidity-coverage';
 const dotenvConfigPath: string = process.env.DOTENV_CONFIG_PATH || '../../.env';
 dotenvConfig({path: resolve(__dirname, dotenvConfigPath), override: true});
 
-if (!process.env.INFURA_API_KEY) {
-  throw new Error('INFURA_API_KEY in .env not set');
-}
-
 // Fetch the accounts specified in the .env file
 function specifiedAccounts(): string[] {
   return process.env.PRIVATE_KEY ? process.env.PRIVATE_KEY.split(',') : [];

--- a/packages/contracts/plugin-settings.ts
+++ b/packages/contracts/plugin-settings.ts
@@ -4,7 +4,7 @@ import {VersionTag} from '@aragon/osx-commons-sdk';
 
 export const PLUGIN_CONTRACT_NAME = 'MyPlugin'; // This must match the filename `packages/contracts/src/MyPlugin.sol` and the contract name `MyPlugin` within.
 export const PLUGIN_SETUP_CONTRACT_NAME = 'MyPluginSetup'; // This must match the filename `packages/contracts/src/MyPluginSetup.sol` and the contract name `MyPluginSetup` within.
-export const PLUGIN_REPO_ENS_SUBDOMAIN_NAME = 'my'; // This will result in the ENS domain name 'my.plugin.dao.eth'
+export const PLUGIN_REPO_ENS_SUBDOMAIN_NAME = 'myP'; // This will result in the ENS domain name 'my.plugin.dao.eth'
 
 export const VERSION: VersionTag = {
   release: 1, // Increment this number ONLY if breaking/incompatible changes were made. Updates between releases are NOT possible.

--- a/packages/contracts/plugin-settings.ts
+++ b/packages/contracts/plugin-settings.ts
@@ -4,7 +4,7 @@ import {VersionTag} from '@aragon/osx-commons-sdk';
 
 export const PLUGIN_CONTRACT_NAME = 'MyPlugin'; // This must match the filename `packages/contracts/src/MyPlugin.sol` and the contract name `MyPlugin` within.
 export const PLUGIN_SETUP_CONTRACT_NAME = 'MyPluginSetup'; // This must match the filename `packages/contracts/src/MyPluginSetup.sol` and the contract name `MyPluginSetup` within.
-export const PLUGIN_REPO_ENS_SUBDOMAIN_NAME = 'myP'; // This will result in the ENS domain name 'my.plugin.dao.eth'
+export const PLUGIN_REPO_ENS_SUBDOMAIN_NAME = 'my'; // This will result in the ENS domain name 'my.plugin.dao.eth'
 
 export const VERSION: VersionTag = {
   release: 1, // Increment this number ONLY if breaking/incompatible changes were made. Updates between releases are NOT possible.

--- a/packages/contracts/utils/helpers.ts
+++ b/packages/contracts/utils/helpers.ts
@@ -39,9 +39,11 @@ export function getProductionNetworkName(
       productionNetworkName = process.env.NETWORK_NAME;
     } else {
       console.log(
+        '\x1b[33m%s\x1b[0m',
         `No network has been provided in the '.env' file. Defaulting to '${SupportedNetworks.SEPOLIA}' as the production network.`
       );
       productionNetworkName = SupportedNetworks.SEPOLIA;
+      process.env.NETWORK_NAME = productionNetworkName;
     }
   } else {
     productionNetworkName = hre.network.name;

--- a/packages/contracts/utils/helpers.ts
+++ b/packages/contracts/utils/helpers.ts
@@ -195,3 +195,21 @@ export async function createVersion(
 
 export const AragonOSxAsciiArt =
   "                                          ____   _____      \n     /\\                                  / __ \\ / ____|     \n    /  \\   _ __ __ _  __ _  ___  _ __   | |  | | (_____  __ \n   / /\\ \\ | '__/ _` |/ _` |/ _ \\| '_ \\  | |  | |\\___ \\ \\/ / \n  / ____ \\| | | (_| | (_| | (_) | | | | | |__| |____) >  <  \n /_/    \\_\\_|  \\__,_|\\__, |\\___/|_| |_|  \\____/|_____/_/\\_\\ \n                      __/ |                                 \n                     |___/                                  \n";
+
+export type NetworkForkConfig = {
+  blockNumber: number;
+};
+
+export type NetworksForkConfig = {
+  [network: string]: NetworkForkConfig;
+};
+
+export const networksForkConfig: NetworksForkConfig = {
+  [SupportedNetworks.SEPOLIA]: {blockNumber: 5387390},
+};
+
+export function getNetworkForkConfig(
+  network: string
+): NetworkForkConfig | undefined {
+  return networksForkConfig[network];
+}


### PR DESCRIPTION
This pull request proposes to optimize the configuration process by avoiding unnecessary setup of the Infura API key. 

Upon reviewing the code, It looks like configuring the Infura API key is unnecessary. This is because the [deployment script ](https://github.com/aragon/osx-plugin-template-hardhat/blob/1b4ff110fee6d245364d9a6580319c1c036acdf8/packages/contracts/deploy/00_info/01_info.ts#L30)forks the network using the configuration defined in [osx-commons](https://github.com/aragon/osx-commons/blob/742d9b2963fecf0392017758d15a279627f81de8/configs/src/networks/getters.ts#L30-L39), and the Infura API key used for this process is already defined in [osx-commons](https://github.com/aragon/osx-commons/blob/develop/configs/src/networks/networks.ts) as well ([481a4cdc7c774286b8627f21c6827f48](https://github.com/aragon/osx-commons/blob/742d9b2963fecf0392017758d15a279627f81de8/configs/src/networks/networks.ts#L21).

Furthermore, after thorough testing, I was able to successfully deploy and test the plugin without explicitly setting the Infura API key. 

Additionally, this PR addresses an issue where the "No network provided" message was being logged unnecessarily, cluttering the output. 
<img width="731" alt="Screenshot 2024-03-05 at 10 40 44" src="https://github.com/aragon/osx-plugin-template-hardhat/assets/26546018/25964f03-4da3-4b56-870f-7f6520361d89">


__NOTE__: ~~I needed to change the plugin subdomain because by mistake, deployed it to Sepolia and the tests failed.~~ 
Added configuration to pin the block number to make the test fork
