### PR TITLE
fix: GitHub actions to run over PR changes instead of commit changes

### DIFF
--- a/.github/workflows/contracts-tests.yml
+++ b/.github/workflows/contracts-tests.yml
@@ -2,7 +2,7 @@ name: 'contracts'
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
     paths:
       - 'packages/contracts/**'
       - '.github/workflows/contracts-*.yml'

--- a/.github/workflows/subgraph-tests.yml
+++ b/.github/workflows/subgraph-tests.yml
@@ -2,7 +2,7 @@ name: 'subgraph'
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
     paths:
       - 'packages/subgraph/**'
       - 'packages/contracts/**'

--- a/README.md
+++ b/README.md
@@ -323,3 +323,5 @@ to deploy the subgraph and check your [Alchemy subgraph dashboard](https://subgr
 ## License
 
 This project is licensed under AGPL-3.0-or-later.
+
+small comment to check pipeline run all needed tests even if the commit is only changing the Readme

--- a/README.md
+++ b/README.md
@@ -323,5 +323,3 @@ to deploy the subgraph and check your [Alchemy subgraph dashboard](https://subgr
 ## License
 
 This project is licensed under AGPL-3.0-or-later.
-
-small comment to check pipeline run all needed tests even if the commit is only changing the Readme


### PR DESCRIPTION
Fix the GitHub action to run over the PR changes instead of the commit changes. 


[OS-1127](https://aragonassociation.atlassian.net/browse/OS-1127)

[OS-1127]: https://aragonassociation.atlassian.net/browse/OS-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ