### PR TITLE
refactor: remove IAction

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -8,3 +8,4 @@ type DaoPlugin @entity {
   "Set plugin specific related data below:"
   number: BigInt
 }
+

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -8,11 +8,3 @@ type DaoPlugin @entity {
   "Set plugin specific related data below:"
   number: BigInt
 }
-
-type IAction @entity {
-    id: ID! #action entity id
-    daoAddress: Bytes!
-    to: Bytes!
-    value: BigInt!
-    data: Bytes!
-}


### PR DESCRIPTION
## Description

IAction is an opinionated interface that is implemented inside OSx Enshrined Plugins and OSx core. However, there is no necessity for plugin developers to use IAction: nothing about a plugin requires that they create an entity in such a specific way. If they require the deterministic ID, this can be fetched from OSx commons and the plugin need not _necessarily_ define it inside an Action Entity. 

To simplify the template and keep it as minimal as possible. We propose to remove IAction. It will remain inside OSx plugins maintained by Aragon, but that's a specific implementation detail. 

As a final point: the reason we came to this conclusion was that explaining the IAction && the ID creation required a long description about the recommended imperative steps to use it "properly." This didn't feel in keeping with the rest of the template and plugin developers should not have to worry about the cognitive overhead of understanding an entity they might not even want/need.

This was surfaced as part of Task ID: [OS-1265](https://aragonassociation.atlassian.net/browse/OS-1265)

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.



[OS-1265]: https://aragonassociation.atlassian.net/browse/OS-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ