### PR TITLE
refactor: remove not needed code on test

### DIFF
--- a/packages/contracts/test/20_integration-testing/21_deployment.ts
+++ b/packages/contracts/test/20_integration-testing/21_deployment.ts
@@ -65,11 +65,6 @@ describe(`Deployment on network '${productionNetworkName}'`, function () {
     it('registers the setup', async () => {
       const {pluginRepo} = await loadFixture(fixture);
 
-      await pluginRepo['getVersion((uint8,uint16))']({
-        release: VERSION.release,
-        build: VERSION.build,
-      });
-
       const results = await pluginRepo['getVersion((uint8,uint16))']({
         release: VERSION.release,
         build: VERSION.build,


### PR DESCRIPTION
This PR only removes a duplication issue that probably resulted from merging. 

The removed code is also duplicated on [the next lines](https://github.com/aragon/osx-plugin-template-hardhat/blob/c70e24ee4f07a52076ba33f93973d99ce8cb8c16/packages/contracts/test/20_integration-testing/21_deployment.ts#L68-L71) 